### PR TITLE
Fix minecraft trigger path

### DIFF
--- a/launch_wrapper.sh
+++ b/launch_wrapper.sh
@@ -1,9 +1,10 @@
 #  launch_wrapper.sh
 #  Handles seamless switching between Basilisk II and Minecraft Pi Edition
 
-TRIGGER_FILE="$HOME/Unix/.launch_minecraft"
+# Shared folder inside the emulator maps to the Pi's Downloads directory
+TRIGGER_FILE="$HOME/Downloads/.launch_minecraft"
 
-# Ensure trigger file directory exists (in case user hasn't launched BasiliskII yet)
+# Ensure trigger file directory exists
 mkdir -p "$(dirname "$TRIGGER_FILE")"
 
 while true; do


### PR DESCRIPTION
## Summary
- fix trigger file path in `launch_wrapper.sh` to watch `~/Downloads`

## Testing
- `bash -n setup.sh`
- `bash -n launch_wrapper.sh`


------
https://chatgpt.com/codex/tasks/task_e_685afc4fc1b88326b793f903d931e50c