### PR TITLE
Fix BasiliskII build by adding MPFR dev dependency

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,7 @@ fi
 
 echo "🔧 Installing dependencies..."
 sudo apt update
-sudo apt install -y build-essential libsdl2-dev libsdl2-image-dev git hfsutils xinit x11-xserver-utils unclutter feh xbindkeys alsa-utils autoconf automake libtool
+sudo apt install -y build-essential libsdl2-dev libsdl2-image-dev git hfsutils xinit x11-xserver-utils unclutter feh xbindkeys alsa-utils autoconf automake libtool libmpfr-dev
 
 if $MINECRAFT_MODE; then
   echo "🧱 Installing Minecraft Pi Edition dependencies..."


### PR DESCRIPTION
## Summary
- add `libmpfr-dev` to the package install list in `setup.sh`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b0211570c832684a4af34ad0df194