### PR TITLE
Fix setup script user paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This project transforms a Raspberry Pi 5 (8GB) running Raspberry Pi OS 64-bit Li
    ```bash
    sudo ./setup.sh --with-minecraft
    ```
+   The script automatically installs files into the account that invoked `sudo`,
+   so running it with `sudo` is sufficient.
 
 4. After reboot, Mac OS 8.1 will launch in fullscreen automatically.
 

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,11 @@ if [ "$EUID" -ne 0 ]; then
   exit 1
 fi
 
+# Determine the non-root user running this script so we can place files in the
+# correct home directory when executed via sudo.
+TARGET_USER="${SUDO_USER:-$USER}"
+USER_HOME=$(eval echo "~$TARGET_USER")
+
 echo "🔧 Installing dependencies..."
 sudo apt update
 sudo apt install -y build-essential libsdl2-dev libsdl2-image-dev git hfsutils xinit x11-xserver-utils unclutter feh xbindkeys alsa-utils autoconf automake libtool libmpfr-dev
@@ -20,8 +25,8 @@ sudo apt install -y build-essential libsdl2-dev libsdl2-image-dev git hfsutils x
 if $MINECRAFT_MODE; then
   echo "🧱 Installing Minecraft Pi Edition dependencies..."
   sudo apt install -y mesa-utils libgl1-mesa-dri libgles2
-  mkdir -p "$HOME/mcpi"
-  cd "$HOME/mcpi"
+  mkdir -p "$USER_HOME/mcpi"
+  cd "$USER_HOME/mcpi"
   wget https://archive.org/download/minecraft-pi/minecraft-pi-0.1.1.tar.gz
   tar -xzf minecraft-pi-0.1.1.tar.gz
   chmod +x minecraft-pi
@@ -37,21 +42,21 @@ sudo make install
 cd ../../../../
 
 echo "📁 Creating macos8 directory..."
-mkdir -p "$HOME/macos8" "$HOME/macos8/Apps"
+mkdir -p "$USER_HOME/macos8" "$USER_HOME/macos8/Apps"
 
 echo "📄 Copying ROM and disk images..."
-cp LC575.ROM "$HOME/macos8/"
-cp DiskTools_MacOS8.image "$HOME/macos8/"
-cp shutdown.png "$HOME/macos8/"
-cp reboot.png "$HOME/macos8/"
+cp LC575.ROM "$USER_HOME/macos8/"
+cp DiskTools_MacOS8.image "$USER_HOME/macos8/"
+cp shutdown.png "$USER_HOME/macos8/"
+cp reboot.png "$USER_HOME/macos8/"
 
 # Reassemble Mac OS 8.1 ISO from parts if not already present
-if [ ! -f "$HOME/macos8/MacOS8_1.iso" ]; then
+if [ ! -f "$USER_HOME/macos8/MacOS8_1.iso" ]; then
   echo "📦 Reassembling Mac OS 8.1 ISO from parts..."
-  cat MacOS8_1/MacOS8_1.iso.part_* > "$HOME/macos8/MacOS8_1.iso"
+  cat MacOS8_1/MacOS8_1.iso.part_* > "$USER_HOME/macos8/MacOS8_1.iso"
   echo "🔍 Verifying checksum..."
-  echo "db5ec7aedcb4a3b8228c262cebcb44cf  $HOME/macos8/MacOS8_1.iso" > "$HOME/macos8/MacOS8_1.iso.md5"
-  if md5sum -c "$HOME/macos8/MacOS8_1.iso.md5"; then
+  echo "db5ec7aedcb4a3b8228c262cebcb44cf  $USER_HOME/macos8/MacOS8_1.iso" > "$USER_HOME/macos8/MacOS8_1.iso.md5"
+  if md5sum -c "$USER_HOME/macos8/MacOS8_1.iso.md5"; then
     echo "✅ ISO checksum verified."
   else
     echo "❌ Checksum mismatch! Aborting setup."
@@ -69,14 +74,14 @@ if $MINECRAFT_MODE; then
 fi
 
 IMG_MB=$((TOTAL_MB - RESERVED_MB))
-dd if=/dev/zero of="$HOME/macos8/macos8.img" bs=1M count=$IMG_MB
-mkfs.hfs "$HOME/macos8/macos8.img"
+dd if=/dev/zero of="$USER_HOME/macos8/macos8.img" bs=1M count=$IMG_MB
+mkfs.hfs "$USER_HOME/macos8/macos8.img"
 
 if [ -d InstallFiles ]; then
   echo "📂 Copying InstallFiles into macos8.img → Applications folder..."
   command -v hmount >/dev/null 2>&1 || { echo "❌ hfsutils not found in PATH. Aborting."; exit 1; }
 
-  hmount "$HOME/macos8/macos8.img"
+  hmount "$USER_HOME/macos8/macos8.img"
 
   if ! hls ":Applications" > /dev/null 2>&1; then
     echo "📁 Applications folder not found. Creating it..."
@@ -106,40 +111,40 @@ fi
 
 
 echo "📑 Copying Basilisk II install prefs..."
-cp BasiliskII.install.prefs "$HOME/.basilisk_ii_prefs"
+cp BasiliskII.install.prefs "$USER_HOME/.basilisk_ii_prefs"
 
 echo "🎛️ Creating overlay scripts..."
-cp shutdown_overlay.sh "$HOME/shutdown_overlay.sh"
-cp reboot_overlay.sh "$HOME/reboot_overlay.sh"
-chmod +x "$HOME/shutdown_overlay.sh" "$HOME/reboot_overlay.sh"
+cp shutdown_overlay.sh "$USER_HOME/shutdown_overlay.sh"
+cp reboot_overlay.sh "$USER_HOME/reboot_overlay.sh"
+chmod +x "$USER_HOME/shutdown_overlay.sh" "$USER_HOME/reboot_overlay.sh"
 
 echo "🧠 Setting up xbindkeys hotkeys..."
-cat <<EOF > "$HOME/.xbindkeysrc"
-/home/pi/shutdown_overlay.sh
+cat <<EOF > "$USER_HOME/.xbindkeysrc"
+$USER_HOME/shutdown_overlay.sh
   Control+Alt + s
 
-/home/pi/reboot_overlay.sh
+$USER_HOME/reboot_overlay.sh
   Control+Alt + r
 EOF
 
 echo "🖥️ Setting up X autostart..."
 if $MINECRAFT_MODE; then
   echo "➡️ Using Minecraft-aware launch wrapper..."
-  cp launch_wrapper.sh "$HOME/launch_wrapper.sh"
-  chmod +x "$HOME/launch_wrapper.sh"
+  cp launch_wrapper.sh "$USER_HOME/launch_wrapper.sh"
+  chmod +x "$USER_HOME/launch_wrapper.sh"
 
-  cat <<EOF > "$HOME/.xinitrc"
+  cat <<EOF > "$USER_HOME/.xinitrc"
 #!/bin/bash
 xset s off
 xset -dpms
 xset s noblank
 unclutter -idle 0 &
 xbindkeys &
-\$HOME/launch_wrapper.sh
+\$USER_HOME/launch_wrapper.sh
 EOF
 else
   echo "➡️ Using standard BasiliskII launch..."
-  cat <<EOF > "$HOME/.xinitrc"
+  cat <<EOF > "$USER_HOME/.xinitrc"
 #!/bin/bash
 xset s off
 xset -dpms
@@ -150,15 +155,15 @@ BasiliskII
 EOF
 fi
 
-chmod +x "$HOME/.xinitrc"
+chmod +x "$USER_HOME/.xinitrc"
 
 echo "👤 Enabling autologin to console..."
 if ! sudo raspi-config nonint do_boot_behaviour B2; then
   echo "⚠️ Autologin setup failed. You may need to enable it manually via raspi-config."
 fi
 
-if ! grep -Fxq "startx" "$HOME/.bash_profile"; then
-  echo "startx" >> "$HOME/.bash_profile"
+if ! grep -Fxq "startx" "$USER_HOME/.bash_profile"; then
+  echo "startx" >> "$USER_HOME/.bash_profile"
 fi
 
 echo "🔐 Setting passwordless sudo for shutdown/reboot..."
@@ -168,7 +173,7 @@ fi
 
 # Post-install cleanup prompt
 read -p "🖥️ Press ENTER after completing Mac OS 8.1 installation to finalize setup..." temp
-cp BasiliskII.final.prefs "$HOME/.basilisk_ii_prefs"
+cp BasiliskII.final.prefs "$USER_HOME/.basilisk_ii_prefs"
 
 echo "✅ Installation media removed from prefs. Ready to boot into Mac OS 8.1."
 


### PR DESCRIPTION
## Summary
- ensure setup.sh installs files into the invoking user's home directory
- clarify in README that running the script with sudo automatically targets the invoking user

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b359a87348326aa9859974a463ed2