### PR TITLE
Switch to MCPI Reborn

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project transforms a Raspberry Pi 5 (8GB) running Raspberry Pi OS 64-bit Li
 - ⌨️ Hotkeys for reboot (`Ctrl+Alt+R`) and shutdown (`Ctrl+Alt+S`) with retro-style overlay screens
 - ✅ Post-install prompt finalizes setup and removes install media
 - 📁 Mounts Pi’s `~/Downloads/` into Mac as “Unix” drive
-- 🧱 Optional Minecraft Pi Edition integration (desktop launcher inside Mac)
+- 🧱 Optional Minecraft Pi Edition Reborn integration (desktop launcher inside Mac)
 
 ---
 
@@ -36,7 +36,7 @@ This project transforms a Raspberry Pi 5 (8GB) running Raspberry Pi OS 64-bit Li
 | `shutdown_overlay.sh`     | Script: show shutdown image and power off                 |
 | `reboot_overlay.sh`       | Script: show reboot image and restart                     |
 | `InstallFiles/`           | Apps auto-copied to `macos8.img/Applications`             |
-| `InstallFiles/Minecraft/` | If `--with-minecraft` flag: `.launch_minecraft` → Applications, `Minecraft` app → Desktop |
+| `InstallFiles/Minecraft/` | If `--with-minecraft` flag: `.launch_minecraft` → Applications, `Minecraft` app → Desktop (Pi Edition Reborn) |
 
 ---
 
@@ -62,7 +62,7 @@ This project transforms a Raspberry Pi 5 (8GB) running Raspberry Pi OS 64-bit Li
    chmod +x setup.sh
    ```
 
-3. Run the setup script (optionally add Minecraft support):
+3. Run the setup script (optionally add Minecraft Pi Edition Reborn support):
    ```bash
    sudo ./setup.sh --with-minecraft
    ```

--- a/launch_wrapper.sh
+++ b/launch_wrapper.sh
@@ -1,5 +1,5 @@
 #  launch_wrapper.sh
-#  Handles seamless switching between Basilisk II and Minecraft Pi Edition
+#  Handles seamless switching between Basilisk II and Minecraft Pi Edition Reborn
 
 # Shared folder inside the emulator maps to the Pi's Downloads directory
 TRIGGER_FILE="$HOME/Downloads/.launch_minecraft"
@@ -17,11 +17,11 @@ while true; do
 
   echo "🔍 Checking for Minecraft trigger..."
   if [ -f "$TRIGGER_FILE" ]; then
-    echo "🧱 Launching Minecraft Pi Edition..."
+  echo "🧱 Launching Minecraft Pi Edition Reborn..."
     rm "$TRIGGER_FILE"
 
-    # Launch Minecraft Pi Edition
-    "$HOME/mcpi/minecraft-pi" &
+  # Launch Minecraft Pi Edition Reborn
+  "$HOME/mcpi-reborn/mcpi-reborn-client" &
     wait
 
     echo "🔁 Returning to Basilisk II..."

--- a/setup.sh
+++ b/setup.sh
@@ -23,13 +23,13 @@ sudo apt update
 sudo apt install -y build-essential libsdl2-dev libsdl2-image-dev git hfsutils xinit x11-xserver-utils unclutter feh xbindkeys alsa-utils autoconf automake libtool libmpfr-dev
 
 if $MINECRAFT_MODE; then
-  echo "🧱 Installing Minecraft Pi Edition dependencies..."
-  sudo apt install -y mesa-utils libgl1-mesa-dri libgles2
-  mkdir -p "$USER_HOME/mcpi"
-  cd "$USER_HOME/mcpi"
-  wget https://archive.org/download/minecraft-pi/minecraft-pi-0.1.1.tar.gz
-  tar -xzf minecraft-pi-0.1.1.tar.gz
-  chmod +x minecraft-pi
+  echo "🧱 Installing Minecraft Pi Edition Reborn dependencies..."
+  sudo apt install -y cmake g++ libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \
+    libsdl2-ttf-dev libcurl4-openssl-dev libglew-dev
+  mkdir -p "$USER_HOME/mcpi-reborn"
+  cd "$USER_HOME/mcpi-reborn"
+  git clone https://github.com/TheBrokenRail/mcpi-reborn.git .
+  ./scripts/install.sh
   cd -
 fi
 


### PR DESCRIPTION
## Summary
- update optional Minecraft instructions for MCPI Reborn
- build MCPI Reborn in setup script
- update launcher to use MCPI Reborn client

## Testing
- `bash -n setup.sh`
- `bash -n launch_wrapper.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b5da0e1648326841bb37ccb5e117d