### PR TITLE
Update setup image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The installer handles all dependencies and will automatically copy the `Minecraf
 | `LC575.ROM`               | Macintosh Quadra ROM file                                 |
 | `DiskTools_MacOS8.image`  | Boot floppy used for installation                         |
 | `MacOS8_1.iso.part_*`     | Split ISO parts (joined automatically)                    |
-| `shutdown.png`            | 800×600+ fullscreen image shown before shutdown           |
-| `reboot.png`              | 800×600+ fullscreen image shown before reboot             |
+| `Images/shutdown_MacBackground.png`            | 800×600+ fullscreen image shown before shutdown           |
+| `Images/reboot_MacBackground.png`              | 800×600+ fullscreen image shown before reboot             |
 | `shutdown_overlay.sh`     | Script: show shutdown image and power off                 |
 | `reboot_overlay.sh`       | Script: show reboot image and restart                     |
 | `InstallFiles/`           | Apps auto-copied to `macos8.img/Applications`             |
@@ -106,7 +106,7 @@ Each action displays a retro-style fullscreen overlay image before execution.
   Drop `.sit`, `.img`, or `.app` files into the `InstallFiles/` folder before running `setup.sh`.
 
 - To customize the reboot/shutdown visuals:  
-  Replace `shutdown.png` and `reboot.png` with your own **800x600+** PNG images.
+  Replace `Images/shutdown_MacBackground.png` and `Images/reboot_MacBackground.png` with your own **800x600+** PNG images.
 
 ---
 

--- a/launch_wrapper.sh
+++ b/launch_wrapper.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 TRIGGER_FILE="$HOME/Downloads/.launch_minecraft"
 MCPI_DIR="$HOME/mcpi-reborn"

--- a/reboot_overlay.sh
+++ b/reboot_overlay.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-feh --fullscreen ~/macos8/reboot.png &
+set -euo pipefail
+feh --fullscreen "$HOME/macos8/reboot.png" &
 FEH_PID=$!
+trap "kill $FEH_PID 2>/dev/null || true" EXIT
 sleep 3
-kill $FEH_PID
+kill "$FEH_PID"
 sudo reboot
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 MINECRAFT_MODE=false
 
@@ -48,8 +48,8 @@ mkdir -p "$USER_HOME/macos8" "$USER_HOME/macos8/Apps"
 echo "📄 Copying ROM and disk images..."
 cp LC575.ROM "$USER_HOME/macos8/"
 cp DiskTools_MacOS8.image "$USER_HOME/macos8/"
-cp shutdown.png "$USER_HOME/macos8/"
-cp reboot.png "$USER_HOME/macos8/"
+cp Images/shutdown_MacBackground.png "$USER_HOME/macos8/shutdown.png"
+cp Images/reboot_MacBackground.png "$USER_HOME/macos8/reboot.png"
 
 if [ ! -f "$USER_HOME/macos8/MacOS8_1.iso" ]; then
   echo "📦 Reassembling Mac OS 8.1 ISO from parts..."
@@ -125,9 +125,9 @@ sudo raspi-config nonint do_boot_behaviour B4
 echo "🔧 Configuring splash screen (optional)..."
 sudo sed -i '/^disable_splash/d' /boot/config.txt
 echo "disable_splash=1" | sudo tee -a /boot/config.txt
-if [ -f apple_splash.png ]; then
+if [ -f Images/apple_splash.png ]; then
   sudo apt install -y plymouth plymouth-themes
-  sudo cp apple_splash.png /usr/share/plymouth/themes/pix/splash.png
+  sudo cp Images/apple_splash.png /usr/share/plymouth/themes/pix/splash.png
 fi
 
 echo "🔐 Setting passwordless sudo for shutdown/reboot..."

--- a/shutdown_overlay.sh
+++ b/shutdown_overlay.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-feh --fullscreen ~/macos8/shutdown.png &
+set -euo pipefail
+feh --fullscreen "$HOME/macos8/shutdown.png" &
 FEH_PID=$!
+trap "kill $FEH_PID 2>/dev/null || true" EXIT
 sleep 3
-kill $FEH_PID
+kill "$FEH_PID"
 sudo shutdown now
+


### PR DESCRIPTION
## Summary
- set strict bash options on all scripts
- copy splash and overlay images from `Images` directory
- update README to point at images in `Images`

## Testing
- `bash -n setup.sh`
- `bash -n launch_wrapper.sh`
- `bash -n shutdown_overlay.sh`
- `bash -n reboot_overlay.sh`


------
https://chatgpt.com/codex/tasks/task_e_685bf3f972188326819f04ac4fe0c806