### PR TITLE
Update setup flow for post-install file copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ The installer handles all dependencies and will automatically copy the `Minecraf
 
 4. After reboot, Mac OS 8.1 will launch in fullscreen automatically.
 
-5. Inside the emulator, complete the OS installation normally.
+5. Inside the emulator, initialize the new disk and complete the OS installation.
 
-6. When prompted in the terminal, press ENTER to finalize setup (removes CD/floppy and reboots into your installed Mac OS 8.1 system).
+6. When the emulator is closed, return to the terminal and press ENTER to copy extra applications and finalize setup (removes CD/floppy and reboots into your installed Mac OS 8.1 system).
 
 ---
 


### PR DESCRIPTION
## Summary
- create macOS disk image without preformatting
- copy InstallFiles only after the user installs Mac OS
- describe the new flow in the README

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bf9b2651483268f703806e3e3f5c5