### PR TITLE
Fix optional minecraft flag in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Execute the commands below on a Raspberry Pi running Raspberry Pi OS 64‑bit. T
 ```bash
 git clone https://github.com/markymark5127/MacintoshPi_BasiliskII_System_8.1.git \
   && cd MacintoshPi_BasiliskII_System_8.1 \
-  && sudo ./setup.sh --with-minecraft
+  && sudo ./setup.sh   # add --with-minecraft if you want Pi Edition Reborn
 ```
 The installer handles all dependencies and will automatically copy the `Minecraft` launcher into the emulated Mac if you use the `--with-minecraft` flag.
 
@@ -76,7 +76,7 @@ The installer handles all dependencies and will automatically copy the `Minecraf
 
 3. Run the setup script (optionally add Minecraft Pi Edition Reborn support):
    ```bash
-   sudo ./setup.sh --with-minecraft
+   sudo ./setup.sh       # pass --with-minecraft to include the game
    ```
    The script automatically installs files into the account that invoked `sudo`,
    so running it with `sudo` is sufficient.

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 MINECRAFT_MODE=false
 
-if [[ "$1" == "--with-minecraft" ]]; then
+if [[ $# -gt 0 && "$1" == "--with-minecraft" ]]; then
   MINECRAFT_MODE=true
   echo "🧱 Minecraft mode enabled — additional steps will be included."
 fi


### PR DESCRIPTION
## Summary
- handle missing argument in `setup.sh` to disable minecraft steps
- clarify optional minecraft flag in README

## Testing
- `bash -n setup.sh`
- `shellcheck setup.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c05e1bec083269ed93425b3741276