### PR TITLE
Use sparse disk image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project transforms a Raspberry Pi 5 (8GB) running Raspberry Pi OS 64-bit De
 
 - 🔧 One-command setup via `setup.sh`
 - 🧱 Builds Basilisk II emulator from source (kanjitalk755 fork)
-- 💽 Dynamically creates `macos8.img` using available SD card space
+- 💽 Dynamically creates `macos8.img` as a sparse file using available SD card space
 - 🎮 Preloaded with classic Mac games and educational apps (optional)
 - 🖥️ Fullscreen-only mode (distraction-free for kids)
 - 🔊 Sound support via ALSA

--- a/setup.sh
+++ b/setup.sh
@@ -63,8 +63,15 @@ echo "💽 Creating dynamic macos8.img..."
 TOTAL_MB=$(df --output=avail / | tail -1)
 TOTAL_MB=$((TOTAL_MB / 1024))
 RESERVED_MB=800
+MAX_MB=30720  # 30 GB limit
 IMG_MB=$((TOTAL_MB - RESERVED_MB))
-dd if=/dev/zero of="$USER_HOME/macos8/macos8.img" bs=1M count=$IMG_MB
+if [ "$IMG_MB" -gt "$MAX_MB" ]; then
+  IMG_MB=$MAX_MB
+fi
+
+echo "🧾 Requested disk image size: ${IMG_MB} MB"
+echo "📂 Creating sparse disk image (instantly allocated, grows as needed)..."
+truncate -s "${IMG_MB}M" "$USER_HOME/macos8/macos8.img"
 
 echo "📑 Copying Basilisk II install prefs..."
 cp BasiliskII.install.prefs "$USER_HOME/.basilisk_ii_prefs"


### PR DESCRIPTION
## Summary
- update README to note sparse file creation
- create the macos8 disk using a sparse file that grows as needed

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c0eb2924c8326a7c77ba17d3bac41